### PR TITLE
Issue 1

### DIFF
--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/AddOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/AddOptions.cs
@@ -171,9 +171,9 @@ namespace LoRaWan.Tools.CLI.Options
         [Option(
             "rx2datarate",
             Required = false,
-            HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): Any of the allowed data rates. EU: SF12BW125, SF11BW125, SF10BW125, SF8BW125, SF7BW125, SF7BW250 or 50. US: SF10BW125, SF9BW125, SF8BW125, SF7BW125, SF8BW500, SF12BW500, SF11BW500, SF10BW500, SF9BW500, SF8BW500, SF8BW500. (optional).",
+            HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): Any of the allowed data rates. EU: 0, 1, 2, 3, 4, 5, 6, or 50. US: 0, 1, 2, 3, 4, 8, 9, 10, 11, 12, 13. (optional).",
             SetName = LoRaDeviceSetName)]
-        public string Rx2DataRate { get; set; }
+        public int Rx2DataRate { get; set; }
 
         [Option(
             "rx1droffset",

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/AddOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/AddOptions.cs
@@ -173,7 +173,7 @@ namespace LoRaWan.Tools.CLI.Options
             Required = false,
             HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): Any of the allowed data rates. EU: 0, 1, 2, 3, 4, 5, 6, or 50. US: 0, 1, 2, 3, 4, 8, 9, 10, 11, 12, 13. (optional).",
             SetName = LoRaDeviceSetName)]
-        public int Rx2DataRate { get; set; }
+        public string Rx2DataRate { get; set; }
 
         [Option(
             "rx1droffset",

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/AddOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/AddOptions.cs
@@ -171,7 +171,7 @@ namespace LoRaWan.Tools.CLI.Options
         [Option(
             "rx2datarate",
             Required = false,
-            HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): Any of the allowed data rates. EU: 0, 1, 2, 3, 4, 5, 6, or 50. US: 0, 1, 2, 3, 4, 8, 9, 10, 11, 12, 13. (optional).",
+            HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): enter either number or DRxx, where xx is the DR number, e.g. for DR10 enter number 10 or 'DR10'.",
             SetName = LoRaDeviceSetName)]
         public string Rx2DataRate { get; set; }
 

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/UpdateOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/UpdateOptions.cs
@@ -95,8 +95,8 @@ namespace LoRaWan.Tools.CLI.Options
         [Option(
             "rx2datarate",
             Required = false,
-            HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): Any of the allowed data rates. EU: SF12BW125, SF11BW125, SF10BW125, SF8BW125, SF7BW125, SF7BW250 or 50. US: SF10BW125, SF9BW125, SF8BW125, SF7BW125, SF8BW500, SF12BW500, SF11BW500, SF10BW500, SF9BW500, SF8BW500, SF8BW500. (optional).")]
-        public int Rx2DataRate { get; set; }
+            HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): Any of the allowed data rates. EU: 0, 1, 2, 3, 4, 5, 6, or 50. US: 0, 1, 2, 3, 4, 8, 9, 10, 11, 12, 13. (optional).")]
+        public string Rx2DataRate { get; set; }
 
         [Option(
             "rx1droffset",

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/UpdateOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/UpdateOptions.cs
@@ -96,7 +96,7 @@ namespace LoRaWan.Tools.CLI.Options
             "rx2datarate",
             Required = false,
             HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): Any of the allowed data rates. EU: SF12BW125, SF11BW125, SF10BW125, SF8BW125, SF7BW125, SF7BW250 or 50. US: SF10BW125, SF9BW125, SF8BW125, SF7BW125, SF8BW500, SF12BW500, SF11BW500, SF10BW500, SF9BW500, SF8BW500, SF8BW500. (optional).")]
-        public string Rx2DataRate { get; set; }
+        public int Rx2DataRate { get; set; }
 
         [Option(
             "rx1droffset",

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/UpdateOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/UpdateOptions.cs
@@ -95,7 +95,7 @@ namespace LoRaWan.Tools.CLI.Options
         [Option(
             "rx2datarate",
             Required = false,
-            HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): Any of the allowed data rates. EU: 0, 1, 2, 3, 4, 5, 6, or 50. US: 0, 1, 2, 3, 4, 8, 9, 10, 11, 12, 13. (optional).")]
+            HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): enter either number or DRxx, where xx is the DR number, e.g. for DR10 enter number 10 or 'DR10'.")]
         public string Rx2DataRate { get; set; }
 
         [Option(

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/IoTDeviceHelper.cs
@@ -1043,7 +1043,7 @@ namespace LoRaWan.Tools.CLI.Helpers
                 twinProperties.Desired[TwinProperty.Deduplication] = ValidationHelper.ConvertToStringTwinProperty(opts.Deduplication);
 
             if (!string.IsNullOrEmpty(opts.Rx2DataRate))
-                twinProperties.Desired[TwinProperty.RX2DataRate] = ValidationHelper.ConvertToUIntTwinProperty(opts.Rx2DataRate);
+                twinProperties.Desired[TwinProperty.RX2DataRate] = ValidationHelper.ConvertToUIntDataRateTwinProperty(opts.Rx2DataRate);
 
             if (!string.IsNullOrEmpty(opts.Rx1DrOffset))
                 twinProperties.Desired[TwinProperty.RX1DROffset] = ValidationHelper.ConvertToUIntTwinProperty(opts.Rx1DrOffset);
@@ -1135,7 +1135,7 @@ namespace LoRaWan.Tools.CLI.Helpers
                 twin.Properties.Desired[TwinProperty.Deduplication] = ValidationHelper.ConvertToStringTwinProperty(opts.Deduplication);
 
             if (!string.IsNullOrEmpty(opts.Rx2DataRate))
-                twin.Properties.Desired[TwinProperty.RX2DataRate] = ValidationHelper.ConvertToUIntTwinProperty(opts.Rx2DataRate);
+                twin.Properties.Desired[TwinProperty.RX2DataRate] = ValidationHelper.ConvertToUIntDataRateTwinProperty(opts.Rx2DataRate);
 
             if (!string.IsNullOrEmpty(opts.Rx1DrOffset))
                 twin.Properties.Desired[TwinProperty.RX1DROffset] = ValidationHelper.ConvertToUIntTwinProperty(opts.Rx1DrOffset);

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/IoTDeviceHelper.cs
@@ -59,7 +59,8 @@ namespace LoRaWan.Tools.CLI.Helpers
             var downlinkEnabled = ReadTwin(twin.Properties.Desired, TwinProperty.DownlinkEnabled);
             var preferredWindow = ReadTwin(twin.Properties.Desired, TwinProperty.PreferredWindow);
             var deduplication = ReadTwin(twin.Properties.Desired, TwinProperty.Deduplication);
-            var rx2DataRate = ReadTwin(twin.Properties.Desired, TwinProperty.RX2DataRate);
+            int rx2DataRate;
+            if (!int.TryParse(ReadTwin(twin.Properties.Desired, TwinProperty.RX2DataRate), out rx2DataRate)) rx2DataRate = -1;
             var rx1DrOffset = ReadTwin(twin.Properties.Desired, TwinProperty.RX1DROffset);
             var rxDelay = ReadTwin(twin.Properties.Desired, TwinProperty.RXDelay);
             var keepAliveTimeout = ReadTwin(twin.Properties.Desired, TwinProperty.KeepAliveTimeout);
@@ -240,9 +241,6 @@ namespace LoRaWan.Tools.CLI.Helpers
 
             if (!string.IsNullOrEmpty(opts.Deduplication))
                 opts.Deduplication = ValidationHelper.CleanString(opts.Deduplication);
-
-            if (!string.IsNullOrEmpty(opts.Rx2DataRate))
-                opts.Rx2DataRate = ValidationHelper.CleanString(opts.Rx2DataRate);
 
             if (!string.IsNullOrEmpty(opts.Rx1DrOffset))
                 opts.Rx1DrOffset = ValidationHelper.CleanString(opts.Rx1DrOffset);
@@ -568,16 +566,13 @@ namespace LoRaWan.Tools.CLI.Helpers
                 }
 
                 // Rx2DataRate
-                if (!string.IsNullOrEmpty(opts.Rx2DataRate))
+                if (!ValidationHelper.ValidateDataRateTwinProperty(opts.Rx2DataRate, out validationError))
                 {
-                    if (!ValidationHelper.ValidateDataRateTwinProperty(opts.Rx2DataRate, out validationError))
-                    {
-                        StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Error, $"Rx2DataRate {opts.Rx2DataRate} is invalid: {validationError}.", opts.DevEui, isVerbose);
-                        isValid = false;
-                    }
-
-                    StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Warning, $"Rx2DataRate is currently not supported for ABP devices.", opts.DevEui, isVerbose);
+                    StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Error, $"Rx2DataRate {opts.Rx2DataRate} is invalid: {validationError}.", opts.DevEui, isVerbose);
+                    isValid = false;
                 }
+
+                StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Warning, $"Rx2DataRate is currently not supported for ABP devices.", opts.DevEui, isVerbose);
 
                 // Rx1DrOffset
                 if (!string.IsNullOrEmpty(opts.Rx1DrOffset))
@@ -642,17 +637,14 @@ namespace LoRaWan.Tools.CLI.Helpers
                 }
 
                 // Rx2DataRate
-                if (!string.IsNullOrEmpty(opts.Rx2DataRate))
+                if (!ValidationHelper.ValidateDataRateTwinProperty(opts.Rx2DataRate, out validationError))
                 {
-                    if (!ValidationHelper.ValidateDataRateTwinProperty(opts.Rx2DataRate, out validationError))
-                    {
-                        StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Error, $"Rx2DataRate {opts.Rx2DataRate} is invalid: {validationError}.", opts.DevEui, isVerbose);
-                        isValid = false;
-                    }
-                    else
-                    {
-                        StatusConsole.WriteLogLineIfVerbose(MessageType.Info, $"Rx2DataRate {opts.Rx2DataRate} is valid.", isVerbose);
-                    }
+                    StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Error, $"Rx2DataRate {opts.Rx2DataRate} is invalid: {validationError}.", opts.DevEui, isVerbose);
+                    isValid = false;
+                }
+                else
+                {
+                    StatusConsole.WriteLogLineIfVerbose(MessageType.Info, $"Rx2DataRate {opts.Rx2DataRate} is valid.", isVerbose);
                 }
 
                 // Rx1DrOffset
@@ -1042,8 +1034,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             if (!string.IsNullOrEmpty(opts.Deduplication))
                 twinProperties.Desired[TwinProperty.Deduplication] = ValidationHelper.ConvertToStringTwinProperty(opts.Deduplication);
 
-            if (!string.IsNullOrEmpty(opts.Rx2DataRate))
-                twinProperties.Desired[TwinProperty.RX2DataRate] = ValidationHelper.ConvertToStringTwinProperty(opts.Rx2DataRate);
+            twinProperties.Desired[TwinProperty.RX2DataRate] = opts.Rx2DataRate;
 
             if (!string.IsNullOrEmpty(opts.Rx1DrOffset))
                 twinProperties.Desired[TwinProperty.RX1DROffset] = ValidationHelper.ConvertToUIntTwinProperty(opts.Rx1DrOffset);
@@ -1134,8 +1125,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             if (!string.IsNullOrEmpty(opts.Deduplication))
                 twin.Properties.Desired[TwinProperty.Deduplication] = ValidationHelper.ConvertToStringTwinProperty(opts.Deduplication);
 
-            if (!string.IsNullOrEmpty(opts.Rx2DataRate))
-                twin.Properties.Desired[TwinProperty.RX2DataRate] = ValidationHelper.ConvertToStringTwinProperty(opts.Rx2DataRate);
+            twin.Properties.Desired[TwinProperty.RX2DataRate] = opts.Rx2DataRate;
 
             if (!string.IsNullOrEmpty(opts.Rx1DrOffset))
                 twin.Properties.Desired[TwinProperty.RX1DROffset] = ValidationHelper.ConvertToUIntTwinProperty(opts.Rx1DrOffset);

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/IoTDeviceHelper.cs
@@ -59,8 +59,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             var downlinkEnabled = ReadTwin(twin.Properties.Desired, TwinProperty.DownlinkEnabled);
             var preferredWindow = ReadTwin(twin.Properties.Desired, TwinProperty.PreferredWindow);
             var deduplication = ReadTwin(twin.Properties.Desired, TwinProperty.Deduplication);
-            int rx2DataRate;
-            if (!int.TryParse(ReadTwin(twin.Properties.Desired, TwinProperty.RX2DataRate), out rx2DataRate)) rx2DataRate = -1;
+            var rx2DataRate = ReadTwin(twin.Properties.Desired, TwinProperty.RX2DataRate);
             var rx1DrOffset = ReadTwin(twin.Properties.Desired, TwinProperty.RX1DROffset);
             var rxDelay = ReadTwin(twin.Properties.Desired, TwinProperty.RXDelay);
             var keepAliveTimeout = ReadTwin(twin.Properties.Desired, TwinProperty.KeepAliveTimeout);
@@ -241,6 +240,9 @@ namespace LoRaWan.Tools.CLI.Helpers
 
             if (!string.IsNullOrEmpty(opts.Deduplication))
                 opts.Deduplication = ValidationHelper.CleanString(opts.Deduplication);
+
+            if (!string.IsNullOrEmpty(opts.Rx2DataRate))
+                opts.Rx2DataRate = ValidationHelper.CleanString(opts.Rx2DataRate);
 
             if (!string.IsNullOrEmpty(opts.Rx1DrOffset))
                 opts.Rx1DrOffset = ValidationHelper.CleanString(opts.Rx1DrOffset);
@@ -566,13 +568,16 @@ namespace LoRaWan.Tools.CLI.Helpers
                 }
 
                 // Rx2DataRate
-                if (!ValidationHelper.ValidateDataRateTwinProperty(opts.Rx2DataRate, out validationError))
+                if (!string.IsNullOrEmpty(opts.Rx2DataRate))
                 {
-                    StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Error, $"Rx2DataRate {opts.Rx2DataRate} is invalid: {validationError}.", opts.DevEui, isVerbose);
-                    isValid = false;
-                }
+                    if (!ValidationHelper.ValidateDataRateTwinProperty(opts.Rx2DataRate, out validationError))
+                    {
+                        StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Error, $"Rx2DataRate {opts.Rx2DataRate} is invalid: {validationError}.", opts.DevEui, isVerbose);
+                        isValid = false;
+                    }
 
-                StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Warning, $"Rx2DataRate is currently not supported for ABP devices.", opts.DevEui, isVerbose);
+                    StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Warning, $"Rx2DataRate is currently not supported for ABP devices.", opts.DevEui, isVerbose);
+                }
 
                 // Rx1DrOffset
                 if (!string.IsNullOrEmpty(opts.Rx1DrOffset))
@@ -637,14 +642,17 @@ namespace LoRaWan.Tools.CLI.Helpers
                 }
 
                 // Rx2DataRate
-                if (!ValidationHelper.ValidateDataRateTwinProperty(opts.Rx2DataRate, out validationError))
+                if (!string.IsNullOrEmpty(opts.Rx2DataRate))
                 {
-                    StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Error, $"Rx2DataRate {opts.Rx2DataRate} is invalid: {validationError}.", opts.DevEui, isVerbose);
-                    isValid = false;
-                }
-                else
-                {
-                    StatusConsole.WriteLogLineIfVerbose(MessageType.Info, $"Rx2DataRate {opts.Rx2DataRate} is valid.", isVerbose);
+                    if (!ValidationHelper.ValidateDataRateTwinProperty(opts.Rx2DataRate, out validationError))
+                    {
+                        StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Error, $"Rx2DataRate {opts.Rx2DataRate} is invalid: {validationError}.", opts.DevEui, isVerbose);
+                        isValid = false;
+                    }
+                    else
+                    {
+                        StatusConsole.WriteLogLineIfVerbose(MessageType.Info, $"Rx2DataRate {opts.Rx2DataRate} is valid.", isVerbose);
+                    }
                 }
 
                 // Rx1DrOffset
@@ -1034,7 +1042,8 @@ namespace LoRaWan.Tools.CLI.Helpers
             if (!string.IsNullOrEmpty(opts.Deduplication))
                 twinProperties.Desired[TwinProperty.Deduplication] = ValidationHelper.ConvertToStringTwinProperty(opts.Deduplication);
 
-            twinProperties.Desired[TwinProperty.RX2DataRate] = opts.Rx2DataRate;
+            if (!string.IsNullOrEmpty(opts.Rx2DataRate))
+                twinProperties.Desired[TwinProperty.RX2DataRate] = ValidationHelper.ConvertToUIntTwinProperty(opts.Rx2DataRate);
 
             if (!string.IsNullOrEmpty(opts.Rx1DrOffset))
                 twinProperties.Desired[TwinProperty.RX1DROffset] = ValidationHelper.ConvertToUIntTwinProperty(opts.Rx1DrOffset);
@@ -1125,7 +1134,8 @@ namespace LoRaWan.Tools.CLI.Helpers
             if (!string.IsNullOrEmpty(opts.Deduplication))
                 twin.Properties.Desired[TwinProperty.Deduplication] = ValidationHelper.ConvertToStringTwinProperty(opts.Deduplication);
 
-            twin.Properties.Desired[TwinProperty.RX2DataRate] = opts.Rx2DataRate;
+            if (!string.IsNullOrEmpty(opts.Rx2DataRate))
+                twin.Properties.Desired[TwinProperty.RX2DataRate] = ValidationHelper.ConvertToUIntTwinProperty(opts.Rx2DataRate);
 
             if (!string.IsNullOrEmpty(opts.Rx1DrOffset))
                 twin.Properties.Desired[TwinProperty.RX1DROffset] = ValidationHelper.ConvertToUIntTwinProperty(opts.Rx1DrOffset);

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/ValidationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/ValidationHelper.cs
@@ -11,31 +11,31 @@ namespace LoRaWan.Tools.CLI.Helpers
 
     internal static class ValidationHelper
     {
-        private static readonly List<int> EuValidDataranges = new List<int>()
+        private static readonly List<string> EuValidDataranges = new List<string>()
             {
-                0, // "SF12BW125", // 0
-                1, // "SF11BW125", // 1
-                2, // "SF10BW125", // 2
-                3, // "SF9BW125", // 3
-                4, // "SF8BW125", // 4
-                5, // "SF7BW125", // 5
-                6, // "SF7BW250", // 6
-                50 // 7 FSK 50
+                "0", // "SF12BW125", // 0
+                "1", // "SF11BW125", // 1
+                "2", // "SF10BW125", // 2
+                "3", // "SF9BW125", // 3
+                "4", // "SF8BW125", // 4
+                "5", // "SF7BW125", // 5
+                "6", // "SF7BW250", // 6
+                "50" // 7 FSK 50
             };
 
-        private static readonly List<int> UsValidDataranges = new List<int>()
+        private static readonly List<string> UsValidDataranges = new List<string>()
             {
-                0, // "SF10BW125", // 0
-                1, // "SF9BW125", // 1
-                2, // "SF8BW125", // 2
-                3, //"SF7BW125", // 3
-                4, // "SF8BW500", // 4
-                8, // "SF12BW500", // 8
-                9, // "SF11BW500", // 9
-                10, // "SF10BW500", // 10
-                11, // "SF9BW500", // 11
-                12, // "SF8BW500", // 12
-                13, // "SF8BW500" // 13
+                "0", // "SF10BW125", // 0
+                "1", // "SF9BW125", // 1
+                "2", // "SF8BW125", // 2
+                "3", //"SF7BW125", // 3
+                "4", // "SF8BW500", // 4
+                "8", // "SF12BW500", // 8
+                "9", // "SF11BW500", // 9
+                "10", // "SF10BW500", // 10
+                "11", // "SF9BW500", // 11
+                "12", // "SF8BW500", // 12
+                "13", // "SF8BW500" // 13
             };
 
         public static string GetDataRatesforLocale(string locale)
@@ -286,7 +286,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return isValid;
         }
 
-        public static bool ValidateDataRateTwinProperty(int rx2dataratePropertyValue, out string error)
+        public static bool ValidateDataRateTwinProperty(string rx2dataratePropertyValue, out string error)
         {
             error = null;
 

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/ValidationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/ValidationHelper.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.Tools.CLI.Helpers
 {
     using System;
+    using System.Linq;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Text;
@@ -11,31 +12,31 @@ namespace LoRaWan.Tools.CLI.Helpers
 
     internal static class ValidationHelper
     {
-        private static readonly List<string> EuValidDataranges = new List<string>()
+        private static readonly List<(int, string)> EuValidDataranges = new()
             {
-                "0", // "SF12BW125", // 0
-                "1", // "SF11BW125", // 1
-                "2", // "SF10BW125", // 2
-                "3", // "SF9BW125", // 3
-                "4", // "SF8BW125", // 4
-                "5", // "SF7BW125", // 5
-                "6", // "SF7BW250", // 6
-                "50" // 7 FSK 50
+                (0, "DR0"), // "SF12BW125" // 0
+                (1, "DR1"), // "SF11BW125" // 1
+                (2, "DR2"), // "SF10BW125" // 2
+                (3, "DR3"), // "SF9BW125" // 3
+                (4, "DR4"), // "SF8BW125" // 4
+                (5, "DR5"), // "SF7BW125" // 5
+                (6, "DR6"), // "SF7BW250" // 6
+                (7, "DR7") // "FSK50" // 7 FSK 50
             };
 
-        private static readonly List<string> UsValidDataranges = new List<string>()
+        private static readonly List<(int, string)> UsValidDataranges = new()
             {
-                "0", // "SF10BW125", // 0
-                "1", // "SF9BW125", // 1
-                "2", // "SF8BW125", // 2
-                "3", //"SF7BW125", // 3
-                "4", // "SF8BW500", // 4
-                "8", // "SF12BW500", // 8
-                "9", // "SF11BW500", // 9
-                "10", // "SF10BW500", // 10
-                "11", // "SF9BW500", // 11
-                "12", // "SF8BW500", // 12
-                "13", // "SF8BW500" // 13
+                (0, "DR0"), // "SF10BW125" // 0
+                (1, "DR1"), // "SF9BW125" // 1
+                (2, "DR2"), // "SF8BW125" // 2
+                (3, "DR3"), // "SF7BW125" // 3
+                (4, "DR4"), // "SF8BW500" // 4
+                (8, "DR8"), // "SF12BW500" // 8
+                (9, "DR9"), // "SF11BW500" // 9
+                (10, "DR10"), // "SF10BW500" // 10
+                (11, "DR11"), // "SF9BW500" // 11
+                (12, "DR12"), // "SF8BW500" // 12
+                (13, "DR13"), // "SF8BW500" // 13
             };
 
         public static string GetDataRatesforLocale(string locale)
@@ -187,6 +188,16 @@ namespace LoRaWan.Tools.CLI.Helpers
             }
         }
 
+        public static dynamic ConvertToUIntDataRateTwinProperty(string rx2datarateValue)
+        {
+            if (uint.TryParse(rx2datarateValue, out var uintProperty))
+                return uintProperty;
+            else if (rx2datarateValue.Length > 2 && uint.TryParse(rx2datarateValue.ToLower().Trim().Substring(2), out var uintPropertyRemaining))
+                return uintPropertyRemaining;
+            else
+                return rx2datarateValue; //should never happen after validation
+        }
+
         public static string ConvertToStringTwinProperty(string property)
         {
             if (!string.IsNullOrEmpty(property))
@@ -290,13 +301,24 @@ namespace LoRaWan.Tools.CLI.Helpers
         {
             error = null;
 
-            if (!EuValidDataranges.Contains(rx2dataratePropertyValue) && !UsValidDataranges.Contains(rx2dataratePropertyValue))
-            {
-                error = "Property is not a valid data rate";
-                return false;
-            }
+            string rx2dataratePropertyValueUppercase = rx2dataratePropertyValue.ToUpper(CultureInfo.InvariantCulture);
 
-            return true;
+            bool isValid =
+                EuValidDataranges
+                    .Where(t => 
+                        t.Item1.ToString() == rx2dataratePropertyValueUppercase || 
+                        t.Item2 == rx2dataratePropertyValueUppercase)
+                    .Any()
+               ||
+                UsValidDataranges
+                    .Where(t =>
+                        t.Item1.ToString() == rx2dataratePropertyValueUppercase ||
+                        t.Item2 == rx2dataratePropertyValueUppercase)
+                    .Any();
+
+            if (!isValid) error = "Property is not a valid data rate";
+
+            return isValid;
         }
 
         public static bool ValidateSensorDecoder(string sensorDecoder, bool isVerbose)

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/ValidationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Helpers/ValidationHelper.cs
@@ -11,31 +11,31 @@ namespace LoRaWan.Tools.CLI.Helpers
 
     internal static class ValidationHelper
     {
-        private static readonly List<string> EuValidDataranges = new List<string>()
+        private static readonly List<int> EuValidDataranges = new List<int>()
             {
-                "SF12BW125", // 0
-                "SF11BW125", // 1
-                "SF10BW125", // 2
-                "SF9BW125", // 3
-                "SF8BW125", // 4
-                "SF7BW125", // 5
-                "SF7BW250", // 6
-                "50" // 7 FSK 50
+                0, // "SF12BW125", // 0
+                1, // "SF11BW125", // 1
+                2, // "SF10BW125", // 2
+                3, // "SF9BW125", // 3
+                4, // "SF8BW125", // 4
+                5, // "SF7BW125", // 5
+                6, // "SF7BW250", // 6
+                50 // 7 FSK 50
             };
 
-        private static readonly List<string> UsValidDataranges = new List<string>()
+        private static readonly List<int> UsValidDataranges = new List<int>()
             {
-                "SF10BW125", // 0
-                "SF9BW125", // 1
-                "SF8BW125", // 2
-                "SF7BW125", // 3
-                "SF8BW500", // 4
-                "SF12BW500", // 8
-                "SF11BW500", // 9
-                "SF10BW500", // 10
-                "SF9BW500", // 11
-                "SF8BW500", // 12
-                "SF8BW500" // 13
+                0, // "SF10BW125", // 0
+                1, // "SF9BW125", // 1
+                2, // "SF8BW125", // 2
+                3, //"SF7BW125", // 3
+                4, // "SF8BW500", // 4
+                8, // "SF12BW500", // 8
+                9, // "SF11BW500", // 9
+                10, // "SF10BW500", // 10
+                11, // "SF9BW500", // 11
+                12, // "SF8BW500", // 12
+                13, // "SF8BW500" // 13
             };
 
         public static string GetDataRatesforLocale(string locale)
@@ -286,11 +286,11 @@ namespace LoRaWan.Tools.CLI.Helpers
             return isValid;
         }
 
-        public static bool ValidateDataRateTwinProperty(string property, out string error)
+        public static bool ValidateDataRateTwinProperty(int rx2dataratePropertyValue, out string error)
         {
             error = null;
 
-            if (!EuValidDataranges.Contains(property) && !UsValidDataranges.Contains(property))
+            if (!EuValidDataranges.Contains(rx2dataratePropertyValue) && !UsValidDataranges.Contains(rx2dataratePropertyValue))
             {
                 error = "Property is not a valid data rate";
                 return false;

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/LoRaWan.Tools.CLI.csproj
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/LoRaWan.Tools.CLI.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <Content Include="appsettings.local.json" Condition="Exists('appsettings.local.json')">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/StatusConsole.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/StatusConsole.cs
@@ -72,7 +72,7 @@ namespace LoRaWan.Tools.CLI
             Console.WriteLine();
             Console.ForegroundColor = ConsoleColor.Yellow;
             Console.WriteLine($"DevEUI: {devEui}");
-            Console.WriteLine(TwinToString(twin));
+            Console.WriteLine(twin is not null ? TwinToString(twin) : "");
             Console.ResetColor();
         }
 

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/StatusConsole.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/StatusConsole.cs
@@ -72,7 +72,7 @@ namespace LoRaWan.Tools.CLI
             Console.WriteLine();
             Console.ForegroundColor = ConsoleColor.Yellow;
             Console.WriteLine($"DevEUI: {devEui}");
-            Console.WriteLine(twin is not null ? TwinToString(twin) : "");
+            Console.WriteLine(TwinToString(twin));
             Console.ResetColor();
         }
 

--- a/Tools/Cli-LoRa-Device-Provisioning/Tests/LoRaWan.Tools.CLI.Tests.Unit/DeviceProvisioningTest.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Tests/LoRaWan.Tools.CLI.Tests.Unit/DeviceProvisioningTest.cs
@@ -441,7 +441,7 @@ namespace LoRaWan.Tools.CLI.Tests.Unit
         [Theory]
         [InlineData("10")]
         [InlineData("SF12BW500")]
-        public async Task ValidateRx2datarate(string rx2datarateValue)
+        public async Task ValidateRx2Datarate(string rx2datarateValue)
         {
             Twin twin = new Twin();
             // Arrange

--- a/Tools/Cli-LoRa-Device-Provisioning/Tests/LoRaWan.Tools.CLI.Tests.Unit/DeviceProvisioningTest.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Tests/LoRaWan.Tools.CLI.Tests.Unit/DeviceProvisioningTest.cs
@@ -443,6 +443,7 @@ namespace LoRaWan.Tools.CLI.Tests.Unit
         [InlineData("SF12BW500")]
         public async Task ValidateRx2datarate(string rx2datarateValue)
         {
+            Twin twin = new Twin();
             // Arrange
             registryManager.Setup(c => c.AddDeviceWithTwinAsync(
                     It.Is<Device>(d => d.Id == DevEUI),
@@ -452,6 +453,8 @@ namespace LoRaWan.Tools.CLI.Tests.Unit
                 {
                     IsSuccessful = true
                 });
+
+            registryManager.Setup(x => x.GetTwinAsync(DevEUI)).ReturnsAsync(twin);
 
             // Act
             var args = CreateArgs($"add --type otaa --deveui {DevEUI} --appeui {AppEUI} --appkey {AppKey}  --decoder {Decoder} --network {NetworkName} --classtype C --rx2datarate {rx2datarateValue}");

--- a/Tools/Cli-LoRa-Device-Provisioning/Tests/LoRaWan.Tools.CLI.Tests.Unit/DeviceProvisioningTest.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Tests/LoRaWan.Tools.CLI.Tests.Unit/DeviceProvisioningTest.cs
@@ -27,7 +27,7 @@ namespace LoRaWan.Tools.CLI.Tests.Unit
 
         // OTAA Properties
         private static readonly string AppKey = GetRandomHexNumber(32);
-        private static readonly string AppEui = GetRandomHexNumber(16);
+        private static readonly string AppEUI = GetRandomHexNumber(16);
 
         // ABP properties
         private static readonly string AppSKey = GetRandomHexNumber(32);
@@ -145,7 +145,7 @@ namespace LoRaWan.Tools.CLI.Tests.Unit
                     Assert.Equal(NetworkName, t.Tags[DeviceTags.NetworkTagName].ToString());
                     Assert.Equal(new string[] { DeviceTags.DeviceTypes.Leaf }, ((JArray)t.Tags[DeviceTags.DeviceTypeTagName]).Select(x => x.ToString()).ToArray());
                     Assert.Equal(AppKey, t.Properties.Desired[TwinProperty.AppKey].ToString());
-                    Assert.Equal(AppEui, t.Properties.Desired[TwinProperty.AppEUI].ToString());
+                    Assert.Equal(AppEUI, t.Properties.Desired[TwinProperty.AppEUI].ToString());
                     Assert.Equal(Decoder, t.Properties.Desired[TwinProperty.SensorDecoder].ToString());
                     Assert.Equal(string.Empty, t.Properties.Desired[TwinProperty.GatewayID].ToString());
                     if (includeTenantId)
@@ -172,7 +172,7 @@ namespace LoRaWan.Tools.CLI.Tests.Unit
             }
 
             // Act
-            var args = CreateArgs($"add --type otaa --deveui {DevEUI} --appeui {AppEui} --appkey {AppKey}  --decoder {Decoder} --network {NetworkName} {(includeTenantId ? $"--tenant-id {TenantId}" : string.Empty)}");
+            var args = CreateArgs($"add --type otaa --deveui {DevEUI} --appeui {AppEUI} --appkey {AppKey}  --decoder {Decoder} --network {NetworkName} {(includeTenantId ? $"--tenant-id {TenantId}" : string.Empty)}");
             var actual = await Program.Run(args, this.configurationHelper);
 
             // Assert
@@ -436,6 +436,30 @@ namespace LoRaWan.Tools.CLI.Tests.Unit
 
             // Assert
             Assert.Equal(-1, actual);
+        }
+
+        [Theory]
+        [InlineData("10")]
+        [InlineData("SF12BW500")]
+        public async Task ValidateRx2datarate(string rx2datarateValue)
+        {
+            // Arrange
+            registryManager.Setup(c => c.AddDeviceWithTwinAsync(
+                    It.Is<Device>(d => d.Id == DevEUI),
+                    It.IsNotNull<Twin>()))
+                .Callback((Device d, Twin t) => Assert.Equal(rx2datarateValue, t.Properties.Desired[TwinProperty.RX2DataRate].ToString()))
+                .ReturnsAsync(new BulkRegistryOperationResult
+                {
+                    IsSuccessful = true
+                });
+
+            // Act
+            var args = CreateArgs($"add --type otaa --deveui {DevEUI} --appeui {AppEUI} --appkey {AppKey}  --decoder {Decoder} --network {NetworkName} --classtype C --rx2datarate {rx2datarateValue}");
+            var actual = await Program.Run(args, configurationHelper);
+
+            if (rx2datarateValue == "10") Assert.Equal(0, actual);
+            else if (rx2datarateValue == "SF12BW500") Assert.Equal(-1, actual);
+            else Assert.True(false);
         }
     }
 }


### PR DESCRIPTION
# PR for issue #1

DR10, 10, or SF10BW500 should be able to be inputted after --rx2datarate and 10 should be the result that goes to the device twin.

## How is this addressed

By mapping the two equivalent formats to the uint format.

<!--
- Describe the changes made, and if appropriate, why they are addressed this way
- Note any pending work (with links to the issues that will address them)
-->
